### PR TITLE
Fix role selection timing in signup e2e tests

### DIFF
--- a/e2e/signup-admin.spec.ts
+++ b/e2e/signup-admin.spec.ts
@@ -14,17 +14,15 @@ test('sign up as pharmacy admin shows dashboard', async ({ page }) => {
 
   await page.goto('/');
 
-  // 新規登録フォームへ
+  // 新規登録フォームへ: 役割を最初に選択
   await page.getByRole('button', { name: '新規登録' }).click();
+  await page.getByRole('button', { name: '薬局管理者' }).click();
 
   // 基本情報
   const uniqueEmail = `admin-${Date.now()}@gmail.com`;
   await page.getByLabel('メールアドレス').fill(uniqueEmail);
   await page.getByLabel('パスワード').fill('password123');
   await page.getByLabel('パスワード確認').fill('password123');
-
-  // 役割選択
-  await page.getByRole('button', { name: '薬局管理者' }).click();
 
   // 薬局情報（必須項目）
   await page.getByLabel('薬局名').fill('テスト薬局');

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -15,17 +15,15 @@ test('sign up redirects to dashboard', async ({ page }) => {
 
   await page.goto('/');
 
-  // switch to sign up form
+  // switch to sign up form and select role first
   await page.getByRole('button', { name: '新規登録' }).click();
+  await page.getByRole('button', { name: '薬剤師' }).click();
 
   // 基本情報
   const uniqueEmail = `test-${Date.now()}@gmail.com`;
   await page.getByLabel('メールアドレス').fill(uniqueEmail);
   await page.getByLabel('パスワード').fill('password123');
   await page.getByLabel('パスワード確認').fill('password123');
-
-  // 役割選択
-  await page.getByRole('button', { name: '薬剤師' }).click();
 
   // 必須項目の入力
   await page.getByLabel('姓').fill('田中');


### PR DESCRIPTION
## Summary
- update signup tests to click role button immediately after opening the signup form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541619ac50832090ca40c5f3544d23