### PR TITLE
Refactor signup tests with role selectors

### DIFF
--- a/e2e/signup-admin.spec.ts
+++ b/e2e/signup-admin.spec.ts
@@ -20,16 +20,16 @@ test('sign up as pharmacy admin shows dashboard', async ({ page }) => {
 
   // 基本情報
   const uniqueEmail = `admin-${Date.now()}@gmail.com`;
-  await page.getByLabel('メールアドレス').fill(uniqueEmail);
-  await page.getByLabel('パスワード').fill('password123');
-  await page.getByLabel('パスワード確認').fill('password123');
+  await page.getByRole('textbox', { name: /メールアドレス/ }).fill(uniqueEmail);
+  await page.getByRole('textbox', { name: /パスワード$/ }).fill('password123');
+  await page.getByRole('textbox', { name: /パスワード確認/ }).fill('password123');
 
   // 薬局情報（必須項目）
-  await page.getByLabel('薬局名').fill('テスト薬局');
-  await page.getByLabel('都道府県').selectOption('東京都');
-  await page.getByLabel('市区町村 *').fill('渋谷区');
-  await page.getByLabel('住所 *').fill('神南1-1-1');
-  await page.getByLabel('電話番号').fill('0312345678');
+  await page.getByRole('textbox', { name: /薬局名/ }).fill('テスト薬局');
+  await page.getByRole('combobox', { name: /都道府県/ }).selectOption('東京都');
+  await page.getByRole('textbox', { name: /市区町村/ }).fill('渋谷区');
+  await page.getByRole('textbox', { name: /住所/ }).fill('神南1-1-1');
+  await page.getByRole('textbox', { name: /電話番号/ }).fill('0312345678');
 
   // フォーム送信
   await page.getByRole('button', { name: 'アカウント作成' }).click();

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -21,32 +21,32 @@ test('sign up redirects to dashboard', async ({ page }) => {
 
   // 基本情報
   const uniqueEmail = `test-${Date.now()}@gmail.com`;
-  await page.getByLabel('メールアドレス').fill(uniqueEmail);
-  await page.getByLabel('パスワード').fill('password123');
-  await page.getByLabel('パスワード確認').fill('password123');
+  await page.getByRole('textbox', { name: /メールアドレス/ }).fill(uniqueEmail);
+  await page.getByRole('textbox', { name: /パスワード$/ }).fill('password123');
+  await page.getByRole('textbox', { name: /パスワード確認/ }).fill('password123');
 
   // 必須項目の入力
-  await page.getByLabel('姓').fill('田中');
-  await page.getByLabel('名').fill('一郎');
+  await page.getByRole('textbox', { name: '姓' }).fill('田中');
+  await page.getByRole('textbox', { name: '名' }).fill('一郎');
 
   await page.getByLabel('生年月日').locator('select').nth(0).selectOption('1990');
   await page.getByLabel('生年月日').locator('select').nth(1).selectOption('1');
   await page.getByLabel('生年月日').locator('select').nth(2).selectOption('1');
-  await page.getByLabel('性別').selectOption('male');
-  await page.getByLabel('携帯電話番号').fill('09012345678');
+  await page.getByRole('combobox', { name: /性別/ }).selectOption('male');
+  await page.getByRole('textbox', { name: /携帯電話番号/ }).fill('09012345678');
 
   // 住所情報
-  await page.getByLabel('郵便番号').fill('1600023');
-  await page.getByLabel('都道府県').selectOption('東京都');
-  await page.getByLabel(/市区町村/).fill('新宿区');
-  await page.getByLabel('住所').fill('西新宿1-1-1');
+  await page.getByRole('textbox', { name: /郵便番号/ }).fill('1600023');
+  await page.getByRole('combobox', { name: /都道府県/ }).selectOption('東京都');
+  await page.getByRole('textbox', { name: /市区町村/ }).fill('新宿区');
+  await page.getByRole('textbox', { name: /住所/ }).fill('西新宿1-1-1');
 
   // 薬剤師情報
-  await page.getByLabel('薬剤師免許番号').fill('123456');
+  await page.getByRole('textbox', { name: /薬剤師免許番号/ }).fill('123456');
   await page.getByLabel('免許取得日').locator('select').nth(0).selectOption('2015');
   await page.getByLabel('免許取得日').locator('select').nth(1).selectOption('1');
   await page.getByLabel('免許取得日').locator('select').nth(2).selectOption('1');
-  await page.getByLabel('総経験年数').fill('5');
+  await page.getByRole('spinbutton', { name: /総経験年数/ }).fill('5');
 
   // フォーム送信
   await page.getByRole('button', { name: 'アカウント作成' }).click();


### PR DESCRIPTION
## Summary
- use `getByRole` for textboxes and combos in signup tests

## Testing
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68541b5c0c108320b346e9bd3bafc91f